### PR TITLE
move cli-tools CI to travis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comments: false

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage.xml
 nosetests.xml
 cover/
 htmlcov/
+.cache
 
 .eggs/
 .python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV="py27-tests,py27-lint,cli,coverage"
+    - python: 3.4
+      env: TOXENV="py34-tests,cli"
+    - python: 3.5
+      env: TOXENV="copying,py35-tests,py35-lint,cli,coverage"
+    - python: 3.6
+      env: TOXENV="py36-tests,cli"
+
+before_install:
+  - pip install tox
+
+install:
+  - pip install .
+
+script:
+  - tox

--- a/DEV.md
+++ b/DEV.md
@@ -6,18 +6,17 @@ These are advices on how to maintain iotlabcli as I do right now.
 Automatic multi version tests
 -----------------------------
 
-Python versions 2.6, 2.7, 3.2, 3.3 and 3.4 are unit-tested
+Python versions 2.7, 3.4, 3.5 and 3.6 are unit-tested
 You can run all tests with:
+```
+$ tox
+```
 
-    tox
-
-Running test for one specific version
-
-    tox -e py26
-    tox -e py32
-
-Python 3.1 does not run due to external dependencies issues.
-
+Running test for one specific version:
+```
+$ tox -e py27
+$ tox -e py35
+```
 
 Step by step validation
 -----------------------
@@ -28,30 +27,23 @@ Development depencencies can be installed with
 
     pip install -r test-requirements
 
-For `python2.6` / `python3.2`
-
-    pip install -r tests_utils/pylint-python-2.6_3.2.txt
-    pip install -r tests_utils/test-requirements
-
 ### Manually running tests ###
 
-    python setup.py lint
-    python setup.py pep8
-    flake8  # it does not work from setup.py script
-    python setup.py nosetests
+```
+$ python setup.py lint
+$ python setup.py pep8
+$ flake8  # it does not work from setup.py script
+$ pytest iotlabcli --ignore=iotlabcli/integration
+```
 
+### Running integration tests ###
+
+```
+$ IOTLAB_TEST_PASSWORD=<password> tox -e integration
+```
 
 Coding constraints
 ------------------
 
-### Python2.6 ###
-
- * unittest.TestCase.assertRaisesRegexp not supported
- * str.format() only used numbered/named argument
-
-
-### Python3.X ###
-
  * Prefer '.format' when formatting strings
  * Use from `__future__ import print_function` and print('str') with parens
-

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 IoT-Lab cli-tools
 =================
 
+[build-icon]: https://travis-ci.org/iot-lab/cli-tools.svg?branch=master
+[build-page]: https://travis-ci.org/iot-lab/cli-tools/branches
+[coverage-icon]: https://codecov.io/gh/iot-lab/cli-tools/branch/master/graph/badge.svg
+[coverage-page]: https://codecov.io/gh/iot-lab/cli-tools
+
+[![build][build-icon]][build-page]  [![codecov][coverage-icon]][coverage-page]
+
 IoT-LAB cli-tools provide a basic set of operations for managing IoT-LAB
 experiments from the command-line.
 
 IoT-LAB cli-tools, including all examples, code snippets and attached
 documentation is covered by the CeCILL v2.1 free software licence.
-
 
 The following commands are available:
 
@@ -39,4 +45,3 @@ To proceede to install cli-tools, use `sudo python setup.py install`.
 Installing cli-tools automatically fetches additional dependencies as needed.
 
 Further documentation: https://github.com/iot-lab/iot-lab/wiki/CLI-Tools
-

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ self-documented.  Use e.g:
 
 
 The cli-tools leverage the IoT-LAB `REST API` and simply wrap calls to
-module `iotlabcli`, which is a Python (2.6 or higher) client for the API.
+module `iotlabcli`, which is a Python (2.7 or higher) client for the API.
 
 The cli-tools come as an installable Python package and require that
 module `setuptools` be installed before tools installation can happen.

--- a/iotlabcli/integration/test_integration.py
+++ b/iotlabcli/integration/test_integration.py
@@ -44,13 +44,12 @@ import logging
 from tempfile import NamedTemporaryFile
 
 try:
-    # pylint:disable=I0011,F0401,E0611
     from mock import patch
+    # pylint:disable=I0011,F0401,E0611
     from cStringIO import StringIO
 except ImportError:  # pragma: no cover
     from unittest.mock import patch  # pylint:disable=I0011,F0401,E0611
     from io import StringIO
-
 
 LOGGER = logging.getLogger(__file__)
 LOGGER.setLevel(logging.INFO)

--- a/iotlabcli/parser/robot.py
+++ b/iotlabcli/parser/robot.py
@@ -39,9 +39,9 @@ def name_site(name_site_str):
     ('name', 'site')
 
     >>> name_site('name')
-    ... # doctest: +ELLIPSIS
+    ... # doctest: +ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-    ValueError: need more than 1 value to unpack...
+    ValueError: not enough values to unpack...
 
     >>> name_site('name,site,extra')
     ... # doctest: +ELLIPSIS

--- a/tests_utils/check_license.sh
+++ b/tests_utils/check_license.sh
@@ -17,6 +17,8 @@ files_list=$(echo "${files_list}" | grep -v \
     -e '.json'\
     -e 'AUTHORS' \
     -e 'COPYING' \
+    -e '.travis.yml' \
+    -e '.codecov.yml' \
 )
 
 # Verify that 'AUTHORS' and 'COPYING' files exist

--- a/tests_utils/coverage-python-3.2.txt
+++ b/tests_utils/coverage-python-3.2.txt
@@ -1,3 +1,0 @@
-# Drop support for python3.2
-# https://bitbucket.org/ned/coveragepy/issues/407/coverage-failing-on-python-325-using
-coverage < 4.0.0

--- a/tests_utils/pylint-python-2.6_3.2.txt
+++ b/tests_utils/pylint-python-2.6_3.2.txt
@@ -1,4 +1,0 @@
-# Not using '2to3' anymore, pylint 1.4 breaks python 2.6 compatibility
-pylint<1.4.0
-logilab-common<0.63
-astroid<1.3.0

--- a/tests_utils/test-requirements.txt
+++ b/tests_utils/test-requirements.txt
@@ -1,8 +1,8 @@
-nose
-nosexcover
-# Force because of python2.6
-mock <= 1.0.1
+pytest
+pytest-cov
+mock
 setuptools-pep8
 setuptools-lint
 # issues with pep8 >= 1.6
 flake8==2.3.0
+codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,24 @@
 [tox]
-# python3.1 issues with 2to3 for dependencies install
-# python3.2 issues with pip/tox
-envlist = copying,cli,py26,py27,py33,py34
-
-[tox:jenkins]
-skip_missing_interpreters = True
+envlist = copying,cli,{py27,py35}-{lint,tests}
 
 [testenv]
+whitelist_externals =
+    cli:   {[testenv:cli]whitelist_externals}
 deps=
     -rtests_utils/test-requirements.txt
-    py26,py32: -rtests_utils/pylint-python-2.6_3.2.txt
-    py32: -rtests_utils/coverage-python-3.2.txt
 commands=
-    python setup.py nosetests
+    tests:       {[testenv:tests]commands}
+    lint:        {[testenv:lint]commands}
+    integration: {[testenv:integration]commands}
+    cli:         {[testenv:cli]commands}
+    coverage:    {[testenv:coverage]commands}
+
+[testenv:tests]
+commands=
+    pytest -v iotlabcli --doctest-modules --cov=iotlabcli --ignore=iotlabcli/integration
+
+[testenv:lint]
+commands=
     python setup.py lint
     python setup.py pep8
     flake8
@@ -27,16 +33,13 @@ whitelist_externals = /bin/bash
 commands=
     bash -exc "for i in *-cli; do $i --help >/dev/null; done"
 
+[testenv:coverage]
+passenv = CI TRAVIS TRAVIS_*
+commands = codecov -e TOXENV
+
 [testenv:integration]
-# Use develop to get 'iotlabcli' coverage output
-# Either it would be in .tox/integration/..../site-packages/
-usedevelop=True
 deps=
     -rtests_utils/test-requirements.txt
 passenv = IOTLAB_TEST_PASSWORD
 commands=
-    pip install --upgrade -e.[secure]  # Install iotlabcli[secure] dependencies
-    coverage run --source iotlabcli --omit='iotlabcli/tests/*' iotlabcli/integration/test_integration.py {posargs}
-    coverage report
-    coverage html
-    coverage xml
+    pytest -v iotlabcli/integration --cov=iotlabcli/integration


### PR DESCRIPTION
Addresses #8 by running the actual unittest suite on travis.
In the mean time, this PR drops the support of python 2.6 and 3.2 but enables the support of python 3.5 and 3.6 (not tested yet).

Bonus: codecov is now also enabled.

~~Next step => switch to pytest (see #9)~~ done in 460adc9