### PR TITLE
iotlabci: fix robot parser doctest with python3

### DIFF
--- a/iotlabcli/parser/robot.py
+++ b/iotlabcli/parser/robot.py
@@ -41,7 +41,7 @@ def name_site(name_site_str):
     >>> name_site('name')
     ... # doctest: +ELLIPSIS
     Traceback (most recent call last):
-    ValueError: need more than 1 value to unpack...
+    ValueError: ...
 
     >>> name_site('name,site,extra')
     ... # doctest: +ELLIPSIS


### PR DESCRIPTION
While playing with pytest in #11, I noticed a doctest was broken in python 3 because of a different exception error message.

This is an attempt to fix it. Other solutions exist but this one doesn't change the test and takes python 2 as reference.