### PR TITLE
Fix new issues with latest pylint version

### DIFF
--- a/iotlabcli/associations.py
+++ b/iotlabcli/associations.py
@@ -64,7 +64,7 @@ class _Association(collections.MutableMapping, dict):
     VALUE = None
     VALUE_SORT_KEY = None
 
-    def __init__(self, key, value):  # pylint:disable=super-init-not-called
+    def __init__(self, key, value):
         # Don't call 'dict' init, only used for json dumping
         self._concrete_class()
         self.key = key

--- a/iotlabcli/associations.py
+++ b/iotlabcli/associations.py
@@ -194,6 +194,7 @@ class _Association(collections.MutableMapping, dict):
         return _disabled_method(self)
 
     def __setitem__(self, *_):  # pragma: no cover
+        # pylint: disable=arguments-differ
         return _disabled_method(self)
 
 

--- a/iotlabcli/helpers.py
+++ b/iotlabcli/helpers.py
@@ -107,7 +107,7 @@ def get_current_exp(exp_by_states, states):
         exps = exp_by_states.get(state, [])
         if len(exps) == 1:
             return exps[0]
-        elif len(exps) == 0:
+        elif not exps:
             continue
         raise ValueError(
             "You have several experiments with state {0!r}\n"

--- a/iotlabcli/helpers.py
+++ b/iotlabcli/helpers.py
@@ -244,7 +244,8 @@ def json_dumps(obj):
     """ Dumps data to json """
     class _Encoder(json.JSONEncoder):  # pylint: disable=too-few-public-methods
         """ Encoder for serialization object python to JSON format """
-        def default(self, obj):  # pylint: disable=method-hidden
+        def default(self, obj):
+            # pylint: disable=method-hidden,arguments-differ
             return obj.__dict__
     return json.dumps(obj, cls=_Encoder, sort_keys=True, indent=4)
 

--- a/iotlabcli/helpers.py
+++ b/iotlabcli/helpers.py
@@ -244,9 +244,9 @@ def json_dumps(obj):
     """ Dumps data to json """
     class _Encoder(json.JSONEncoder):  # pylint: disable=too-few-public-methods
         """ Encoder for serialization object python to JSON format """
-        def default(self, obj):
+        def default(self, o):
             # pylint: disable=method-hidden,arguments-differ
-            return obj.__dict__
+            return o.__dict__
     return json.dumps(obj, cls=_Encoder, sort_keys=True, indent=4)
 
 

--- a/iotlabcli/parser/common.py
+++ b/iotlabcli/parser/common.py
@@ -96,6 +96,7 @@ class HelpAction(argparse.Action):
     HELPMSG = None
 
     def __init__(self, *args, **kwargs):
+        # pylint: disable=useless-super-delegation
         super(HelpAction, self).__init__(*args, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):

--- a/iotlabcli/parser/common.py
+++ b/iotlabcli/parser/common.py
@@ -95,10 +95,6 @@ class HelpAction(argparse.Action):
 
     HELPMSG = None
 
-    def __init__(self, *args, **kwargs):
-        # pylint: disable=useless-super-delegation
-        super(HelpAction, self).__init__(*args, **kwargs)
-
     def __call__(self, parser, namespace, values, option_string=None):
         print(self.HELPMSG, end='')
         parser.exit()

--- a/iotlabcli/parser/experiment.py
+++ b/iotlabcli/parser/experiment.py
@@ -20,7 +20,6 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 """ Experiment parser """
-# pylint:disable=protected-access
 
 import sys
 import time

--- a/iotlabcli/parser/experiment.py
+++ b/iotlabcli/parser/experiment.py
@@ -20,6 +20,7 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 """ Experiment parser """
+# pylint:disable=protected-access
 
 import sys
 import time
@@ -690,8 +691,8 @@ def get_experiment_parser(opts):
     api = rest.Api(user, passwd)
 
     if opts.get_cmd == 'experiment_list':
-        return experiment.get_experiments_list(api, opts.state, opts.limit,
-                                               opts.offset)
+        ret = experiment.get_experiments_list(api, opts.state, opts.limit,
+                                              opts.offset)
     elif opts.get_cmd == 'start':
         exp_id = helpers.get_current_experiment(api, opts.experiment_id,
                                                 running_only=False)
@@ -700,13 +701,14 @@ def get_experiment_parser(opts):
         # Add a 'date' field
         timestamp = ret['start_time']
         ret['local_date'] = time.ctime(timestamp) if timestamp else 'Unknown'
-        return ret
     elif opts.get_cmd == 'experiments':
-        return experiment.get_active_experiments(api,
-                                                 running_only=not opts.active)
+        ret = experiment.get_active_experiments(api,
+                                                running_only=not opts.active)
     else:
         exp_id = helpers.get_current_experiment(api, opts.experiment_id)
-        return experiment.get_experiment(api, exp_id, opts.get_cmd)
+        ret = experiment.get_experiment(api, exp_id, opts.get_cmd)
+
+    return ret
 
 
 def load_experiment_parser(opts):

--- a/iotlabcli/parser/profile.py
+++ b/iotlabcli/parser/profile.py
@@ -280,9 +280,11 @@ def _custom_profile(opts):
 def _add_profile(api, name, profile, json_out=False):
     """ Add user profile. if json, dump json dict to stdout """
     if json_out:
-        return profile
+        ret = profile
     else:
-        return api.add_profile(name, profile)
+        ret = api.add_profile(name, profile)
+
+    return ret
 
 
 def add_profile_parser(api, opts):

--- a/iotlabcli/profile.py
+++ b/iotlabcli/profile.py
@@ -68,7 +68,7 @@ class ProfileM3A8(object):
         """ Configure radio measures """
         if not mode:
             return
-        assert len(channels)
+        assert channels
         for channel in channels:
             assert channel in self.choices['radio']['channels']
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ cover-package      = iotlabcli
 
 [lint]
 lint-reports = no
-lint-disable = locally-disabled,star-args,bad-option-value
+lint-disable = locally-disabled,star-args,bad-option-value,super-init-not-called
 lint-msg-template = {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 
 [pep8]


### PR DESCRIPTION
The latest pylint version doesn't allow anymore the following issues: len-as-condition, no-else-return and arguments-differ.

I fixed the first two ones by slightly updating the code. The last one is just ignored.