### PR TITLE
Use iotlab-* pattern instead of *-cli in command names

### DIFF
--- a/auth-cli
+++ b/auth-cli
@@ -20,4 +20,6 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 import iotlabcli.parser.auth
-iotlabcli.parser.auth.main()
+from iotlabcli.helpers import deprecate_cmd
+
+deprecate_cmd(iotlabcli.parser.auth.main, "auth-cli", "iotlab-auth")

--- a/experiment-cli
+++ b/experiment-cli
@@ -20,4 +20,7 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 import iotlabcli.parser.experiment
-iotlabcli.parser.experiment.main()
+from iotlabcli.helpers import deprecate_cmd
+
+deprecate_cmd(iotlabcli.parser.experiment.main,
+              "experiment-cli", "iotlab-experiment")

--- a/iotlab-admin
+++ b/iotlab-admin
@@ -20,6 +20,4 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 import iotlabcli.parser.admin
-from iotlabcli.helpers import deprecate_cmd
-
-deprecate_cmd(iotlabcli.parser.admin.main, "admin-cli", "iotlab-admin")
+iotlabcli.parser.admin.main()

--- a/iotlab-auth
+++ b/iotlab-auth
@@ -19,7 +19,5 @@
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
-import iotlabcli.parser.admin
-from iotlabcli.helpers import deprecate_cmd
-
-deprecate_cmd(iotlabcli.parser.admin.main, "admin-cli", "iotlab-admin")
+import iotlabcli.parser.auth
+iotlabcli.parser.auth.main()

--- a/iotlab-experiment
+++ b/iotlab-experiment
@@ -19,7 +19,5 @@
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
-import iotlabcli.parser.admin
-from iotlabcli.helpers import deprecate_cmd
-
-deprecate_cmd(iotlabcli.parser.admin.main, "admin-cli", "iotlab-admin")
+import iotlabcli.parser.experiment
+iotlabcli.parser.experiment.main()

--- a/iotlab-node
+++ b/iotlab-node
@@ -19,7 +19,5 @@
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
-import iotlabcli.parser.admin
-from iotlabcli.helpers import deprecate_cmd
-
-deprecate_cmd(iotlabcli.parser.admin.main, "admin-cli", "iotlab-admin")
+import iotlabcli.parser.node
+iotlabcli.parser.node.main()

--- a/iotlab-profile
+++ b/iotlab-profile
@@ -19,7 +19,5 @@
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
-import iotlabcli.parser.admin
-from iotlabcli.helpers import deprecate_cmd
-
-deprecate_cmd(iotlabcli.parser.admin.main, "admin-cli", "iotlab-admin")
+import iotlabcli.parser.profile
+iotlabcli.parser.profile.main()

--- a/iotlab-robot
+++ b/iotlab-robot
@@ -19,7 +19,5 @@
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
-import iotlabcli.parser.admin
-from iotlabcli.helpers import deprecate_cmd
-
-deprecate_cmd(iotlabcli.parser.admin.main, "admin-cli", "iotlab-admin")
+import iotlabcli.parser.robot
+iotlabcli.parser.robot.main()

--- a/iotlabcli/helpers.py
+++ b/iotlabcli/helpers.py
@@ -254,7 +254,6 @@ def json_dumps(obj):
     return json.dumps(obj, cls=_Encoder, sort_keys=True, indent=4)
 
 
-
 def flatten_list_list(list_list):
     """Flatten given list of list.
 

--- a/iotlabcli/helpers.py
+++ b/iotlabcli/helpers.py
@@ -25,12 +25,17 @@ import sys
 import os
 import json
 import itertools
+import warnings
 
 OAR_STATES = ["Waiting", "toLaunch", "Launching",
               "Running",
               "Finishing",
               "Terminated", "Error"]
 ACTIVE_STATES = OAR_STATES[OAR_STATES.index('Running')::-1]
+
+DEPRECATION_MESSAGE = ("{old_cmd} command is deprecated and will be removed "
+                       "in next release. Please \033[1muse {new_cmd} "
+                       "instead\033[0m.\n\n")
 
 
 def get_current_experiment(api, experiment_id=None, running_only=True):
@@ -249,6 +254,7 @@ def json_dumps(obj):
     return json.dumps(obj, cls=_Encoder, sort_keys=True, indent=4)
 
 
+
 def flatten_list_list(list_list):
     """Flatten given list of list.
 
@@ -256,3 +262,11 @@ def flatten_list_list(list_list):
     [1, 2, 3, 4, 5, 6, 7, 8]
     """
     return list(itertools.chain.from_iterable(list_list))
+
+
+def deprecate_cmd(cmd_func, old_cmd, new_cmd):
+    """Display a deprecation warning message and run command."""
+    warnings.simplefilter('always', DeprecationWarning)
+    warnings.warn(DEPRECATION_MESSAGE.format(old_cmd=old_cmd, new_cmd=new_cmd),
+                  DeprecationWarning, stacklevel=3)
+    cmd_func()

--- a/iotlabcli/tests/helpers_test.py
+++ b/iotlabcli/tests/helpers_test.py
@@ -24,6 +24,7 @@
 
 import unittest
 import sys
+import warnings
 
 from iotlabcli import helpers
 from iotlabcli.tests import my_mock
@@ -84,6 +85,22 @@ class TestHelpers(unittest.TestCase):
             read_file_mock.side_effect = None
             read_file_mock.return_value = 'API_URL_CUSTOM'
             self.assertEqual('API_URL_CUSTOM', helpers.read_custom_api_url())
+
+
+    def test_deprecate_command(self):
+        """Test command deprecation."""
+        def fake_cmd():
+            """Dummy test function"""
+            pass
+
+        with warnings.catch_warnings(record=True) as w:
+            helpers.deprecate_cmd(fake_cmd, "old", "new")
+
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert helpers.DEPRECATION_MESSAGE.format(old_cmd="old",
+                                                  new_cmd="new") \
+            in str(w[-1].message)
 
 
 class TestFilesDict(unittest.TestCase):

--- a/iotlabcli/tests/helpers_test.py
+++ b/iotlabcli/tests/helpers_test.py
@@ -86,21 +86,20 @@ class TestHelpers(unittest.TestCase):
             read_file_mock.return_value = 'API_URL_CUSTOM'
             self.assertEqual('API_URL_CUSTOM', helpers.read_custom_api_url())
 
-
     def test_deprecate_command(self):
         """Test command deprecation."""
         def fake_cmd():
             """Dummy test function"""
             pass
 
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as warn:
             helpers.deprecate_cmd(fake_cmd, "old", "new")
 
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
-        assert helpers.DEPRECATION_MESSAGE.format(old_cmd="old",
-                                                  new_cmd="new") \
-            in str(w[-1].message)
+        self.assertEqual(len(warn), 1)
+        self.assertTrue(issubclass(warn[-1].category, DeprecationWarning))
+        self.assertTrue(helpers.DEPRECATION_MESSAGE.format(old_cmd="old",
+                                                           new_cmd="new")
+                        in str(warn[-1].message))
 
 
 class TestFilesDict(unittest.TestCase):

--- a/node-cli
+++ b/node-cli
@@ -20,4 +20,6 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 import iotlabcli.parser.node
-iotlabcli.parser.node.main()
+from iotlabcli.helpers import deprecate_cmd
+
+deprecate_cmd(iotlabcli.parser.node.main, "node-cli", "iotlab-node")

--- a/profile-cli
+++ b/profile-cli
@@ -20,4 +20,6 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 import iotlabcli.parser.profile
-iotlabcli.parser.profile.main()
+from iotlabcli.helpers import deprecate_cmd
+
+deprecate_cmd(iotlabcli.parser.profile.main, "profile-cli", "iotlab-profile")

--- a/robot-cli
+++ b/robot-cli
@@ -20,4 +20,6 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 import iotlabcli.parser.robot
-iotlabcli.parser.robot.main()
+from iotlabcli.helpers import deprecate_cmd
+
+deprecate_cmd(iotlabcli.parser.robot.main, "robot-cli", "iotlab-robot")

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,11 @@ def get_version(package):
                 return eval(line.split('=')[-1])  # pylint:disable=eval-used
 
 
-SCRIPTS = ['auth-cli', 'experiment-cli', 'node-cli', 'profile-cli',
-           'robot-cli', 'admin-cli']
+SCRIPTS = ['iotlab-auth', 'iotlab-experiment', 'iotlab-node', 'iotlab-profile',
+           'iotlab-robot', 'iotlab-admin']
+DEPRECATED_SCRIPTS = ['auth-cli', 'experiment-cli', 'node-cli', 'profile-cli',
+                      'robot-cli', 'admin-cli']
+SCRIPTS += DEPRECATED_SCRIPTS
 
 LONG_DESCRIPTION_FILES = ['README.rst', 'CHANGELOG.rst']
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ commands=
 whitelist_externals = /bin/bash
 commands=
     bash -exc "for i in *-cli; do $i --help >/dev/null; done"
+    bash -exc "for i in auth experiment node profile robot; \
+    do iotlab-$i --help > /dev/null; done"
 
 [testenv:checksetup]
 deps =


### PR DESCRIPTION
As discussed on the ML, this PR is an attempt to smoothly switch the command line tool names from `*-cli` to `iotlab-*`.

I kept the previous ones but a deprecation warning message is raised when they are called. This message invites the user to use the new command.