### PR TITLE
add codecov integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ matrix:
     - python: 2.6
       env: TOXENV="py26-tests,cli"
     - python: 2.7
-      env: TOXENV="py27-tests,py27-lint,cli"
+      env: TOXENV="py27-tests,py27-lint,cli,coverage"
     - python: 3.4
       env: TOXENV="py34-tests,cli"
     - python: 3.5
-      env: TOXENV="copying,py35-tests,py35-lint,cli"
+      env: TOXENV="copying,py35-tests,py35-lint,cli,coverage"
     - python: 3.6
       env: TOXENV="py36-tests,cli"
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 IoT-Lab cli-tools
 =================
 
-|PyPI| |Travis|
+|PyPI| |Travis| |Codecov|
 
 IoT-LAB cli-tools provide a basic set of operations for managing IoT-LAB
 experiments from the command-line.
@@ -58,7 +58,6 @@ needed.
 
 Further documentation: https://github.com/iot-lab/iot-lab/wiki/CLI-Tools
 
-
 .. |PyPI| image:: https://badge.fury.io/py/iotlabcli.svg
    :target: https://badge.fury.io/py/iotlabcli
    :alt: PyPI package status
@@ -66,3 +65,7 @@ Further documentation: https://github.com/iot-lab/iot-lab/wiki/CLI-Tools
 .. |Travis| image:: https://travis-ci.org/iot-lab/cli-tools.svg?branch=master
    :target: https://travis-ci.org/iot-lab/cli-tools
    :alt: Travis build status
+
+.. |Codecov| image:: https://codecov.io/gh/iot-lab/cli-tools/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/iot-lab/cli-tools/branch/master
+   :alt: Codecov coverage status

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/tests_utils/check_license.sh
+++ b/tests_utils/check_license.sh
@@ -25,6 +25,7 @@ files_list=$(echo "${files_list}" | grep -v \
     -e 'iotlabcli/tests/scriptconfig' \
     -e 'examples/' \
     -e '.travis.yml' \
+    -e 'codecov.yml' \
 )
 
 # Verify that 'AUTHORS' and 'COPYING' files exist

--- a/tests_utils/test-requirements.txt
+++ b/tests_utils/test-requirements.txt
@@ -6,3 +6,4 @@ mock <= 1.0.1
 setuptools-lint
 # issues with pep8 >= 1.6
 flake8==2.3.0
+codecov>=1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands=
     lint:       {[testenv:lint]commands}
     cli:        {[testenv:cli]commands}
     checksetup: {[testenv:checksetup]commands}
+    coverage:   {[testenv:coverage]commands}
 
 [testenv:tests]
 commands=
@@ -51,6 +52,10 @@ whitelist_externals = /bin/echo
 commands=
     # "python setup.py check" not supported on python2.6
     echo "Disabled for python2.6"
+
+[testenv:coverage]
+passenv = CI TRAVIS TRAVIS_*
+commands = codecov -e TOXENV
 
 [testenv:integration]
 # Use develop to get 'iotlabcli' coverage output


### PR DESCRIPTION
Add [codecov integration](https://codecov.io) integration for nice coverage reports:
* run codecov at the end of a build of travis
* add badge in readme