### PR TITLE
Fix: TypeError calling _load_assocs on previously exported experiment

### DIFF
--- a/iotlabcli/experiment.py
+++ b/iotlabcli/experiment.py
@@ -528,6 +528,13 @@ class _Experiment(object):  # pylint:disable=too-many-instance-attributes
 
         experiment.type = exp_dict.pop('type')
         experiment.nodes = exp_dict.pop('nodes')
+
+        if 'profiles' in exp_dict:
+            del exp_dict['profiles']
+
+        if 'mobilities' in exp_dict:
+            del exp_dict['mobilities']
+
         experiment._load_assocs(**exp_dict)  # pylint:disable=protected-access
         # No checking
         return experiment

--- a/iotlabcli/experiment.py
+++ b/iotlabcli/experiment.py
@@ -497,6 +497,8 @@ class _Experiment(object):  # pylint:disable=too-many-instance-attributes
         self.profileassociations = None
         self.associations = None
         self.siteassociations = None
+        self.profiles = None
+        self.mobilities = None
 
     def _firmwareassociations(self):
         """Init and return firmwareassociations."""
@@ -529,11 +531,11 @@ class _Experiment(object):  # pylint:disable=too-many-instance-attributes
         experiment.type = exp_dict.pop('type')
         experiment.nodes = exp_dict.pop('nodes')
 
-        if 'profiles' in exp_dict:
-            del exp_dict['profiles']
+        if 'profiles' in exp_dict.keys():
+            experiment.profiles = exp_dict.pop('profiles')
 
-        if 'mobilities' in exp_dict:
-            del exp_dict['mobilities']
+        if 'mobilities' in exp_dict.keys():
+            experiment.mobilities = exp_dict.pop('mobilities')
 
         experiment._load_assocs(**exp_dict)  # pylint:disable=protected-access
         # No checking

--- a/iotlabcli/tests/experiment_test.py
+++ b/iotlabcli/tests/experiment_test.py
@@ -109,6 +109,8 @@ class TestExperimentSubmit(CommandMock):
             'firmwareassociations': None,
             'associations': None,
             'siteassociations': None,
+            'profiles': None,
+            'mobilities': None,
         }
         self.assertEqual(expected, json.loads(call_dict['new_exp.json']))
 
@@ -165,6 +167,8 @@ class TestExperimentSubmit(CommandMock):
             ],
             'associations': None,
             'siteassociations': None,
+            'profiles': None,
+            'mobilities': None,
         }
         self.assertEqual(expected, exp_desc)
         self.assertTrue('firmware.elf' in files_dict)
@@ -217,6 +221,8 @@ class TestExperimentSubmit(CommandMock):
                     {'kernelname': 'linux', 'nodes': nodes}],
             },
             'siteassociations': None,
+            'profiles': None,
+            'mobilities': None,
         }
         self.assertEqual(expected, json.loads(call_dict['new_exp.json']))
 
@@ -298,6 +304,8 @@ class TestExperimentSubmit(CommandMock):
                     },
                 ],
             },
+            'profiles': None,
+            'mobilities': None,
         }
         self.assertEqual(expected, json.loads(files_dict['new_exp.json']))
         self.assertEqual(files_dict['script.sh'], SCRIPTS['script.sh'])
@@ -381,6 +389,8 @@ class TestExperimentSubmit(CommandMock):
                     "sites": ['grenoble'],
                 }],
             },
+            'profiles': None,
+            'mobilities': None,
         }
         read_file_mock.side_effect = self._read_file_for_load
 


### PR DESCRIPTION
Exporting an experiment using the GET method creates a JSON file that contains the fields `profiles` and `mobilities`. When `_load_assocs` gets called on the arguments obtained from the exported JSON file, these two parameters are passed as additional keyword arguments and a TypeError occurs.

This can be reproduced using the example from `experiment-cli load --help`
```shell
$ experiment-cli get -i 192 -a
$ tar -xzvf 192.tar.gz
$ experiment-cli load -f 192/192.json
```