### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 
 matrix:
   include:
-    - python: 2.6
-      env: TOXENV="py26-tests,cli"
     - python: 2.7
       env: TOXENV="py27-tests,py27-lint,cli,coverage"
     - python: 3.4

--- a/DEV.md
+++ b/DEV.md
@@ -6,17 +6,15 @@ These are advices on how to maintain iotlabcli as I do right now.
 Automatic multi version tests
 -----------------------------
 
-Python versions 2.6, 2.7, 3.2, 3.3 and 3.4 are unit-tested
+Python versions 2.7, 3.4, 3.5 and 3.6 are unit-tested.
 You can run all tests with:
 
     tox
 
 Running test for one specific version
 
-    tox -e py26
-    tox -e py32
-
-Python 3.1 does not run due to external dependencies issues.
+    tox -e py27
+    tox -e py36
 
 
 Step by step validation
@@ -26,12 +24,8 @@ Step by step validation
 
 Development depencencies can be installed with
 
-    pip install -r test-requirements
-
-For `python2.6` / `python3.2`
-
-    pip install -r tests_utils/pylint-python-2.6_3.2.txt
     pip install -r tests_utils/test-requirements
+
 
 ### Manually running tests ###
 
@@ -43,12 +37,6 @@ For `python2.6` / `python3.2`
 
 Coding constraints
 ------------------
-
-### Python2.6 ###
-
- * unittest.TestCase.assertRaisesRegexp not supported
- * str.format() only used numbered/named argument
-
 
 ### Python3.X ###
 

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,7 @@ Description
 -----------
 
 The cli-tools leverage the IoT-LAB ``REST API`` and simply wrap calls to
-module ``iotlabcli``, which is a Python (2.6 or higher) client for the
-API.
+module ``iotlabcli``, which is a Python client for the API.
 
 The cli-tools come as an installable Python package and require that
 module ``setuptools`` be installed before tools installation can happen.

--- a/iotlabcli/associations.py
+++ b/iotlabcli/associations.py
@@ -59,7 +59,7 @@ class _Association(collections.MutableMapping, dict):
     Inherit from dict to be dumped as a dict by json.
     """
     __metaclass__ = abc.ABCMeta
-    KEYFMT = '{0}name'
+    KEYFMT = '{}name'
     KEY = None
     VALUE = None
     VALUE_SORT_KEY = None
@@ -136,7 +136,7 @@ class _Association(collections.MutableMapping, dict):
     @classmethod
     def for_key_value(cls, key, value, sortkey=None):
         """Create association class for assoctype."""
-        name = '{0}{1}Association'.format(key.title(), value.title())
+        name = '{}{}Association'.format(key.title(), value.title())
 
         class KeyValuesAssociation(cls):  # pylint:disable=too-many-ancestors
             """KeyValuesAssociation class->Nodes."""

--- a/iotlabcli/experiment.py
+++ b/iotlabcli/experiment.py
@@ -484,7 +484,7 @@ _NODESMAPKWARGS = dict(resource='nodes', sortkey=helpers.node_url_sort_key)
 class _Experiment(object):  # pylint:disable=too-many-instance-attributes
     """ Class describing an experiment """
 
-    ASSOCATTR_FMT = '{0}associations'
+    ASSOCATTR_FMT = '{}associations'
 
     def __init__(self, name, duration, start_time=None):
         self.duration = duration
@@ -615,7 +615,7 @@ class _Experiment(object):  # pylint:disable=too-many-instance-attributes
         # Check that nodes are not already present
         _intersect = list(set(self.nodes) & set(nodes_list))
         if _intersect:
-            raise ValueError("Nodes specified multiple times {0}".format(
+            raise ValueError("Nodes specified multiple times {}".format(
                 _intersect))
 
         self.nodes.extend(nodes_list)

--- a/iotlabcli/experiment.py
+++ b/iotlabcli/experiment.py
@@ -178,7 +178,7 @@ def _files_with_filespath(files, filespath):
     ValueError: Filespath ['dir/c'] not in files list ['a', 'b']
     """
     # Change filespath to a dict by basename
-    filespathdict = dict(((basename(f), f) for f in filespath))
+    filespathdict = {basename(f): f for f in filespath}
 
     # Update to full filepath if provided
     updatedfiles = [filespathdict.pop(f, f) for f in set(files)]

--- a/iotlabcli/helpers.py
+++ b/iotlabcli/helpers.py
@@ -204,7 +204,7 @@ def read_custom_api_url():
         api_url = os.getenv('IOTLAB_API_URL')
 
     if api_url:
-        sys.stderr.write("Using custom api_url: {0}\n".format(api_url))
+        sys.stderr.write("Using custom api_url: {}\n".format(api_url))
     return api_url
 
 

--- a/iotlabcli/integration/test_integration.py
+++ b/iotlabcli/integration/test_integration.py
@@ -350,7 +350,7 @@ class TestCliToolsProfile(unittest.TestCase):
         """ Test creating M3 profiles and deleting them """
 
         profs = call_cli('profile-cli get -l')
-        profiles_names = set([p['profilename'] for p in profs])
+        profiles_names = {p['profilename'] for p in profs}
 
         self._add_prof('profile-cli addm3 -n {}', self.profile['m3'])
         profiles_names.add(self.profile['m3'])
@@ -368,7 +368,7 @@ class TestCliToolsProfile(unittest.TestCase):
 
         # check that profiles have been added
         profs = call_cli('profile-cli get -l')
-        profiles_names_new = set([p['profilename'] for p in profs])
+        profiles_names_new = {p['profilename'] for p in profs}
         self.assertEqual(profiles_names, profiles_names_new)
 
         self._del_prof(self.profile['m3'])
@@ -379,7 +379,7 @@ class TestCliToolsProfile(unittest.TestCase):
         """ Test creating wsn430 profiles and deleting them """
 
         profs = call_cli('profile-cli get -l')
-        profiles_names = set([p['profilename'] for p in profs])
+        profiles_names = {p['profilename'] for p in profs}
 
         self._add_prof('profile-cli addwsn430 -n {}', self.profile['wsn430'])
         profiles_names.add(self.profile['wsn430'])
@@ -393,7 +393,7 @@ class TestCliToolsProfile(unittest.TestCase):
 
         # check that profiles have been added
         profs = call_cli('profile-cli get -l')
-        profiles_names_new = set([p['profilename'] for p in profs])
+        profiles_names_new = {p['profilename'] for p in profs}
         self.assertEqual(profiles_names, profiles_names_new)
 
         self._del_prof(self.profile['wsn430'])

--- a/iotlabcli/integration/test_integration.py
+++ b/iotlabcli/integration/test_integration.py
@@ -100,7 +100,7 @@ class TestCliToolsExperiments(unittest.TestCase):
         self._wait_state_or_finished()
 
         # Test get start-time
-        cmd = 'experiment-cli get --start-time -i {0}'.format(self.exp_id)
+        cmd = 'experiment-cli get --start-time -i {}'.format(self.exp_id)
         self.assertNotEqual(0, call_cli(cmd)['start_time'])
 
     def test_an_experiment_alias_multi_same_node(self):
@@ -156,7 +156,7 @@ class TestCliToolsExperiments(unittest.TestCase):
         """ Run an experiment on m3 nodes simple"""
         site = NODES['m3']
 
-        cmd = 'experiment-cli info -li --site {0}'.format(site)
+        cmd = 'experiment-cli info -li --site {}'.format(site)
 
         nodes = self._find_working_nodes(site, 'm3', 3)
         cmd = 'experiment-cli submit -d 5 -n test_cli -l {} '.format(nodes)
@@ -255,7 +255,7 @@ class TestCliToolsExperiments(unittest.TestCase):
 
     def _wait_state_or_finished(self, states='Error,Terminated'):
         """ Wait experiment get in state, or states error and terminated """
-        cmd = 'experiment-cli wait --state {0} --step 5 -i {1}'.format(
+        cmd = 'experiment-cli wait --state {} --step 5 -i {}'.format(
             states, self.exp_id)
         LOGGER.info(cmd)
         return call_cli(cmd)

--- a/iotlabcli/node.py
+++ b/iotlabcli/node.py
@@ -59,7 +59,7 @@ def node_command(api, command, exp_id, nodes_list=(), cmd_opt=None):
         files[NODE_FILENAME] = json.dumps(nodes_list)
         result = api.node_profile_load(exp_id, files)
     elif command == 'profile':
-        cmd_opt = '&name={0}'.format(cmd_opt)
+        cmd_opt = '&name={}'.format(cmd_opt)
         result = api.node_command(command, exp_id, nodes_list, cmd_opt)
     else:
         result = api.node_command(command, exp_id, nodes_list)

--- a/iotlabcli/parser/admin.py
+++ b/iotlabcli/parser/admin.py
@@ -50,7 +50,7 @@ def wait_experiment_parser(opts):
     """ Parse namespace 'opts' object and execute requested 'wait' command """
 
     sys.stderr.write(
-        "Waiting that experiment {0}/{1} gets in state {2}\n".format(
+        "Waiting that experiment {}/{} gets in state {}\n".format(
             opts.experiment_id, opts.exp_user, opts.state))
 
     return admin.wait_user_experiment(opts.experiment_id, opts.exp_user,

--- a/iotlabcli/parser/common.py
+++ b/iotlabcli/parser/common.py
@@ -26,6 +26,7 @@ import sys
 import errno
 import argparse
 import contextlib
+from collections import OrderedDict
 
 # pylint: disable=wrong-import-order
 try:
@@ -34,12 +35,6 @@ try:
 except ImportError:  # pragma: no cover
     # pylint: disable=import-error,no-name-in-module
     from urllib2 import HTTPError
-try:
-    # pylint: disable=import-error,no-name-in-module
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    # pylint: disable=import-error,no-name-in-module
-    from backport_collections import OrderedDict
 
 import jmespath
 

--- a/iotlabcli/parser/experiment.py
+++ b/iotlabcli/parser/experiment.py
@@ -745,7 +745,7 @@ def wait_experiment_parser(opts):
     exp_id = helpers.get_current_experiment(
         api, opts.experiment_id, running_only=False)
 
-    sys.stderr.write("Waiting that experiment {0} gets in state {1}\n".format(
+    sys.stderr.write("Waiting that experiment {} gets in state {}\n".format(
         exp_id, opts.state))
 
     return experiment.wait_experiment(api, exp_id, opts.state,

--- a/iotlabcli/rest.py
+++ b/iotlabcli/rest.py
@@ -89,7 +89,7 @@ class Api(object):  # pylint:disable=too-many-public-methods
 
         url = 'experiments?%s' % ('id' if list_id else 'resources')
         for selection, value in sorted(selections.items()):
-            url += '&{0}={1}'.format(selection, value)
+            url += '&{}={}'.format(selection, value)
         return self.method(url)
 
     def submit_experiment(self, files):
@@ -218,7 +218,7 @@ class Api(object):  # pylint:disable=too-many-public-methods
         """
         url = 'profiles'
         if archi is not None:
-            url += '?archi={0}'.format(archi)
+            url += '?archi={}'.format(archi)
         return self.method(url)
 
     def get_profile(self, name):

--- a/iotlabcli/rest.py
+++ b/iotlabcli/rest.py
@@ -326,7 +326,7 @@ class Api(object):  # pylint:disable=too-many-public-methods
         :param **kwargs: requests.request additional arguments """
         try:
             return requests.request(method, url, **kwargs)
-        except:  # show issue with old requests versions
+        except Exception:  # show issue with old requests versions
             raise RuntimeError(sys.exc_info())
 
     @staticmethod

--- a/iotlabcli/tests/c23.py
+++ b/iotlabcli/tests/c23.py
@@ -34,11 +34,6 @@ if version_info[0] == 2:  # pragma: no cover
     from urllib2 import HTTPError
     import mock
     from cStringIO import StringIO
-elif version_info[0:2] <= (3, 2):  # pragma: no cover
-    # python3.2
-    from urllib.error import HTTPError
-    import mock
-    from io import StringIO
 elif version_info[0] == 3:  # pragma: no cover
     # python3
     from urllib.error import HTTPError

--- a/iotlabcli/tests/experiment_test.py
+++ b/iotlabcli/tests/experiment_test.py
@@ -354,7 +354,7 @@ class TestExperimentSubmit(CommandMock):
             self.api, experiment.EXP_FILENAME, ['firmware.elf'])
 
         # read_file_calls
-        _files = set([_call[0][0] for _call in read_file_mock.call_args_list])
+        _files = {_call[0][0] for _call in read_file_mock.call_args_list}
         self.assertEqual(_files,
                          set((experiment.EXP_FILENAME,
                               'firmware.elf', 'firmware_2.elf')))
@@ -398,7 +398,7 @@ class TestExperimentSubmit(CommandMock):
             self.api, experiment.EXP_FILENAME, ['script.sh'])
 
         # read_file_calls
-        _files = set([_call[0][0] for _call in read_file_mock.call_args_list])
+        _files = {_call[0][0] for _call in read_file_mock.call_args_list}
         self.assertEqual(_files,
                          set((experiment.EXP_FILENAME,
                               'firmware.elf', 'script.sh', 'scriptconfig')))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@
 # knowledge of the CeCILL license and that you accept its terms.
 
 import os
-import sys
 from setuptools import setup, find_packages
 
 PACKAGE = 'iotlabcli'
@@ -54,11 +53,6 @@ SCRIPTS = ['auth-cli', 'experiment-cli', 'node-cli', 'profile-cli',
 
 LONG_DESCRIPTION_FILES = ['README.rst', 'CHANGELOG.rst']
 
-INSTALL_REQUIRES = ['argparse', 'requests>2.4.2', 'jmespath']
-if sys.version_info[0:2] == (2, 6):
-    # OrderedDict and Counter added in python2.7
-    INSTALL_REQUIRES.append('backport_collections')
-
 
 setup(
     name=PACKAGE,
@@ -77,12 +71,11 @@ setup(
     classifiers=['Development Status :: 5 - Production/Stable',
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 2',
-                 'Programming Language :: Python :: 2.6',
                  'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.3',
                  'Programming Language :: Python :: 3.4',
                  'Programming Language :: Python :: 3.5',
+                 'Programming Language :: Python :: 3.6',
                  'Intended Audience :: End Users/Desktop',
                  'Environment :: Console',
                  'Topic :: Utilities', ],
@@ -91,5 +84,6 @@ setup(
         #     security.html#openssl-pyopenssl
         'secure': ['pyOpenSSL', 'ndg-httpsclient', 'pyasn1'],
     },
-    install_requires=INSTALL_REQUIRES,
+    install_requires=['requests>2.4.2', 'jmespath'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
 )

--- a/tests_utils/pylint-python-2.6.txt
+++ b/tests_utils/pylint-python-2.6.txt
@@ -1,4 +1,0 @@
-# Not using '2to3' anymore, pylint 1.4 breaks python 2.6 compatibility
-pylint<1.4.0
-logilab-common<0.63
-astroid<1.3.0

--- a/tests_utils/test-requirements.txt
+++ b/tests_utils/test-requirements.txt
@@ -1,8 +1,7 @@
 pytest
 pytest-cov
 pytest-pep8
-# Force because of python2.6
-mock <= 1.0.1
+mock
 setuptools-lint
 # issues with pep8 >= 1.6
 flake8==2.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = copying,{py26,py27,py33,py34,py35}-{lint,tests,cli,checksetup}
+envlist = copying,{py27,py33,py34,py35,py36}-{lint,tests,cli,checksetup}
 
 [testenv]
 whitelist_externals =
     cli:   {[testenv:cli]whitelist_externals}
 deps=
     -rtests_utils/test-requirements.txt
-    py26: -rtests_utils/pylint-python-2.6.txt
     checksetup: {[testenv:checksetup]deps}
 commands=
     tests:      {[testenv:tests]commands}
@@ -18,10 +17,6 @@ commands=
 [testenv:tests]
 commands=
     py.test
-
-# Issue whith dependencies not being updated for python2.6 in 'cli' mode
-[testenv:py26-cli]
-recreate = True
 
 [testenv:lint]
 commands=
@@ -46,12 +41,6 @@ skip_install = True
 usedevelop = False
 commands =
     python setup.py check --strict --metadata --restructuredtext
-
-[testenv:py26-checksetup]
-whitelist_externals = /bin/echo
-commands=
-    # "python setup.py check" not supported on python2.6
-    echo "Disabled for python2.6"
 
 [testenv:coverage]
 passenv = CI TRAVIS TRAVIS_*


### PR DESCRIPTION
Fixes #19.

Also removes some redundant code for the already-dropped (and EOL) Python 3.2.

Also modernises some things.