### PR TITLE
Small coverage improvements in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ test_auth_file
 
 # pytest cache directory
 .cache/
+.pytest_cache/
 test-report.xml

--- a/iotlabcli/tests/associations_test.py
+++ b/iotlabcli/tests/associations_test.py
@@ -147,9 +147,5 @@ class TestAssociation(unittest.TestCase):
         assocclass = associations._Association.for_key_value('firmware',
                                                              'nodes')
         assoc = assocclass('test.elf', ['m3-1', 'm3-2', 'm3-3'])
-        try:
-            assoc.update
-        except AttributeError:
-            pass
-        else:
-            self.assertRaises(AttributeError, assoc.update)
+        with self.assertRaises(AttributeError):
+            assoc.update()

--- a/iotlabcli/tests/experiment_test.py
+++ b/iotlabcli/tests/experiment_test.py
@@ -365,6 +365,9 @@ class TestExperimentSubmit(CommandMock):
             self.api, experiment.EXP_FILENAME,
             ['firmware.elf', 'firmware_2.elf', 'firmware_3.elf'])
 
+        self.assertRaises(ValueError,
+                          self._read_file_for_load, 'invalid/file/path')
+
     @patch('iotlabcli.helpers.read_file')
     def test_experiment_load_with_script(self, read_file_mock):
         """Try experiment_load with script."""

--- a/iotlabcli/tests/helpers_test.py
+++ b/iotlabcli/tests/helpers_test.py
@@ -114,12 +114,9 @@ class TestFilesDict(unittest.TestCase):
 
         # Cannot add a different valu
         file_dict['b'] = 2
-        try:
+
+        with self.assertRaises(ValueError):
             file_dict['b'] = 3
-        except ValueError:
-            pass  # different value
-        else:
-            self.fail('No ValueError on different values')
 
         # Check dict
         self.assertEqual(file_dict, {'a': 1, 'b': 2})


### PR DESCRIPTION
This PR modifies the tests to reach the 100% coverage in the tools.

It also ignores the `.pytest_cache` directory (apparently generated with recent versions of pytest)