### PR TITLE
test: improve pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [tool:pytest]
-addopts = -v --ignore=iotlabcli/integration
-          --cov=iotlabcli --cov-report=term --cov-report=xml --cov-report=html
+addopts = -v --ignore iotlabcli/integration
           --junit-xml=test-report.xml
-          --doctest-modules iotlabcli
+          --doctest-modules
           --pep8
+testpaths = iotlabcli
 
 [lint]
 lint-reports = no

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands=
 
 [testenv:tests]
 commands=
-    py.test
+    py.test --cov=iotlabcli --cov-report=term --cov-report=xml --cov-report=html
 
 [testenv:lint]
 commands=


### PR DESCRIPTION
This PR is an attempt to fix #28:

- It fixes a configuration issue preventing a single test to be run from pytest
- It moves the coverage option to tox.ini tests env so it's not displayed by default when running pytest