### PR TITLE
iotlab command with subcommands for iotlab-*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ dist: xenial
 matrix:
   include:
     - python: 2.7
-      env: TOXENV="py27-tests,py27-lint,cli,coverage"
+      env: TOXENV="py27-tests,py27-tools,py27-lint,cli,coverage"
     - python: 3.4
       env: TOXENV="py34-tests,cli"
     - python: 3.5
-      env: TOXENV="copying,py35-tests,py35-lint,cli,coverage"
+      env: TOXENV="copying,py35-tests,py35-tools,py35-lint,cli,coverage"
     - python: 3.6
       env: TOXENV="py36-tests,cli"
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ dist: xenial
 matrix:
   include:
     - python: 2.7
-      env: TOXENV="py27-tests,py27-tools,py27-lint,cli,coverage"
+      env: TOXENV="py27-tests,coverage_upload,py27-tools,coverage_upload,py27-lint,cli"
     - python: 3.4
       env: TOXENV="py34-tests,cli"
     - python: 3.5
-      env: TOXENV="copying,py35-tests,py35-tools,py35-lint,cli,coverage"
+      env: TOXENV="copying,py35-tests,coverage_upload,py35-tools,coverage_upload,py35-lint,cli"
     - python: 3.6
       env: TOXENV="py36-tests,cli"
     - python: 3.7

--- a/iotlab
+++ b/iotlab
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# This file is a part of IoT-LAB cli-tools
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+import iotlabcli.parser.main
+iotlabcli.parser.main.main()

--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -36,19 +36,19 @@ try:
     import iotlabaggregator
 except (ImportError, TypeError):
     # TypeError for aggregation-tools, not py3 compatible yet
-    iotlabaggregator = None
+    iotlabaggregator = None  # pylint:disable=invalid-name
 
 # from ssh-cli-tools
 try:
     import iotlabsshcli.parser.open_a8_parser
 except ImportError:
-    iotlabsshcli = None
+    iotlabsshcli = None  # pylint:disable=invalid-name
 
 # from oml-plot-tools
 try:
     import oml_plot_tools
 except (ImportError, SyntaxError, TypeError):
-    oml_plot_tools = None
+    oml_plot_tools = None  # pylint:disable=invalid-name
 
 
 def parse_subcommands(commands, args=None):

--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -33,28 +33,22 @@ import iotlabcli.parser.robot
 
 # from aggregation-tools
 try:
-    from iotlabaggregator.serial import main as aggregator_serial_main
-    from iotlabaggregator.sniffer import main as aggregator_sniffer_main
-    AGGREGATION_TOOLS = True
+    import iotlabaggregator
 except (ImportError, TypeError):
     # TypeError for aggregation-tools, not py3 compatible yet
-    AGGREGATION_TOOLS = False
+    iotlabaggregator = None
 
 # from ssh-cli-tools
 try:
-    from iotlabsshcli.parser.open_a8_parser import main as ssh_main
-    SSH_TOOLS = True  # pragma: nocover
+    import iotlabsshcli.parser.open_a8_parser
 except ImportError:
-    SSH_TOOLS = False
+    iotlabsshcli = None
 
 # from oml-plot-tools
 try:
-    from oml_plot_tools.consum import main as oml_plot_consum_main
-    from oml_plot_tools.radio import main as oml_plot_radio_main  # noqa # pragma: nocover
-    from oml_plot_tools.traj import main as oml_plot_traj_main  # noqa # pragma: nocover
-    OMLPLOT_TOOLS = True  # pragma: nocover
+    import oml_plot_tools
 except (ImportError, SyntaxError, TypeError):
-    OMLPLOT_TOOLS = False
+    oml_plot_tools = None
 
 
 def parse_subcommands(commands, args=None):
@@ -75,8 +69,8 @@ def aggregator(args):
     """'iotlab aggregator' main function."""
 
     commands = {
-        'sniffer': aggregator_sniffer_main,
-        'serial': aggregator_serial_main
+        'sniffer': iotlabaggregator.sniffer.main,
+        'serial': iotlabaggregator.serial.main
     }
     parse_subcommands(commands, args)
 
@@ -85,9 +79,9 @@ def oml_plot(args):
     """'iotlab oml-plot' main function."""
 
     commands = {
-        'consum': oml_plot_consum_main,
-        'radio': oml_plot_radio_main,
-        'traj': oml_plot_traj_main
+        'consum': oml_plot_tools.consum.main,
+        'radio': oml_plot_tools.radio.main,
+        'traj': oml_plot_tools.traj.main
     }
     parse_subcommands(commands, args)
 
@@ -104,11 +98,11 @@ def main(args=None):
         'robot': iotlabcli.parser.robot.main,
         'help': None
     }
-    if AGGREGATION_TOOLS:
+    if iotlabaggregator:
         commands['aggregator'] = aggregator
-    if OMLPLOT_TOOLS:
+    if oml_plot_tools:
         commands['oml-plot'] = oml_plot
-    if SSH_TOOLS:
-        commands['ssh'] = ssh_main
+    if iotlabsshcli:
+        commands['ssh'] = iotlabsshcli.parser.open_a8_parser.main
 
     return parse_subcommands(commands, args)

--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# This file is a part of IoT-LAB cli-tools
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+"""Main parser."""
+
+import sys
+from argparse import ArgumentParser
+
+import iotlabcli.parser.auth
+import iotlabcli.parser.admin
+import iotlabcli.parser.experiment
+import iotlabcli.parser.node
+import iotlabcli.parser.profile
+import iotlabcli.parser.robot
+
+
+def main(args=None):
+    """'iotlab' main function."""
+    args = args or sys.argv[1:]
+
+    commands = {
+        'auth': iotlabcli.parser.auth.main,
+        'admin': iotlabcli.parser.admin.main,
+        'experiment': iotlabcli.parser.experiment.main,
+        'node': iotlabcli.parser.node.main,
+        'profile': iotlabcli.parser.profile.main,
+        'robot': iotlabcli.parser.robot.main,
+        'help': None
+    }
+
+    parser = ArgumentParser()
+    parser.add_argument('command', nargs='?',
+                        choices=commands.keys(), default='help')
+    commands['help'] = lambda args: parser.print_help()
+
+    opts, args = parser.parse_known_args(args)
+
+    return commands[opts.command](args)

--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -43,16 +43,16 @@ except (ImportError, TypeError):
 # from ssh-cli-tools
 try:
     from iotlabsshcli.parser.open_a8_parser import main as ssh_main
-    SSH_TOOLS = True
+    SSH_TOOLS = True  # pragma: nocover
 except ImportError:
     SSH_TOOLS = False
 
 # from oml-plot-tools
 try:
     from oml_plot_tools.consum import main as oml_plot_consum_main
-    from oml_plot_tools.radio import main as oml_plot_radio_main
-    from oml_plot_tools.traj import main as oml_plot_traj_main
-    OMLPLOT_TOOLS = True
+    from oml_plot_tools.radio import main as oml_plot_radio_main  # noqa # pragma: nocover
+    from oml_plot_tools.traj import main as oml_plot_traj_main  # noqa # pragma: nocover
+    OMLPLOT_TOOLS = True  # pragma: nocover
 except (ImportError, SyntaxError, TypeError):
     OMLPLOT_TOOLS = False
 

--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -36,7 +36,8 @@ try:
     from iotlabaggregator.serial import main as aggregator_serial_main
     from iotlabaggregator.sniffer import main as aggregator_sniffer_main
     AGGREGATION_TOOLS = True
-except ImportError:
+except (ImportError, TypeError):
+    # TypeError for aggregation-tools, not py3 compatible yet
     AGGREGATION_TOOLS = False
 
 # from ssh-cli-tools

--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -33,7 +33,8 @@ import iotlabcli.parser.robot
 
 # from aggregation-tools
 try:
-    import iotlabaggregator
+    import iotlabaggregator.serial
+    import iotlabaggregator.sniffer
 except (ImportError, TypeError):
     # TypeError for aggregation-tools, not py3 compatible yet
     iotlabaggregator = None  # pylint:disable=invalid-name
@@ -65,16 +66,6 @@ def parse_subcommands(commands, args=None):
     return commands[opts.command](args)
 
 
-def aggregator(args):
-    """'iotlab aggregator' main function."""
-
-    commands = {
-        'sniffer': iotlabaggregator.sniffer.main,
-        'serial': iotlabaggregator.serial.main
-    }
-    parse_subcommands(commands, args)
-
-
 def oml_plot(args):
     """'iotlab oml-plot' main function."""
 
@@ -99,9 +90,10 @@ def main(args=None):
         'help': None
     }
     if iotlabaggregator:
-        commands['aggregator'] = aggregator
+        commands['serial'] = iotlabaggregator.serial.main
+        commands['sniffer'] = iotlabaggregator.sniffer.main
     if oml_plot_tools:
-        commands['oml-plot'] = oml_plot
+        commands['plot'] = oml_plot
     if iotlabsshcli:
         commands['ssh'] = iotlabsshcli.parser.open_a8_parser.main
 

--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -53,7 +53,7 @@ try:
     from oml_plot_tools.radio import main as oml_plot_radio_main
     from oml_plot_tools.traj import main as oml_plot_traj_main
     OMLPLOT_TOOLS = True
-except ImportError:
+except (ImportError, SyntaxError, TypeError):
     OMLPLOT_TOOLS = False
 
 

--- a/iotlabcli/tests/main_parser_test.py
+++ b/iotlabcli/tests/main_parser_test.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+# This file is a part of IoT-LAB cli-tools
+# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Contributor(s) : see AUTHORS file
+#
+# This software is governed by the CeCILL license under French law
+# and abiding by the rules of distribution of free software.  You can  use,
+# modify and/ or redistribute the software under the terms of the CeCILL
+# license as circulated by CEA, CNRS and INRIA at the following URL
+# http://www.cecill.info.
+#
+# As a counterpart to the access to the source code and  rights to copy,
+# modify and redistribute granted by the license, users are provided only
+# with a limited warranty  and the software's author,  the holder of the
+# economic rights,  and the successive licensors  have only  limited
+# liability.
+#
+# The fact that you are presently reading this means that you have had
+# knowledge of the CeCILL license and that you accept its terms.
+
+""" Test the iotlabcli.experiment_parser module """
+import argparse
+import sys
+
+import pytest
+
+import iotlabcli.parser.main as main_parser
+
+from .c23 import patch
+
+
+@pytest.mark.parametrize('entry',
+                         ['auth', 'admin', 'experiment',
+                          'node', 'profile', 'robot'])
+def test_main_parser(entry):
+    """ Experiment parser """
+    with patch('iotlabcli.parser.%s.main' % entry) as entrypoint_func:
+        main_parser.main([entry, '-i', '123'])
+        entrypoint_func.assert_called_with(['-i', '123'])
+
+
+@pytest.mark.parametrize('argv,exc', argvalues=(
+    (['iotlab'], None), (['iotlab', 'help'], None),
+    (['iotlab', '--help'], SystemExit),
+), ids=['no subcommand', 'help subcommand', '--help argument'])
+def test_help(argv, exc):
+    """Tests that the help entrypoints print the help."""
+    with patch.object(argparse.ArgumentParser, 'print_help') \
+            as argparser_print_help, \
+            patch.object(sys, 'argv', argv):
+        if exc:
+            with pytest.raises(exc):
+                main_parser.main()
+        else:
+            main_parser.main()
+        argparser_print_help.assert_called()

--- a/iotlabcli/tests/main_parser_test.py
+++ b/iotlabcli/tests/main_parser_test.py
@@ -24,10 +24,15 @@ import argparse
 import sys
 
 import pytest
+from mock import Mock, mock
 
 import iotlabcli.parser.main as main_parser
 
 from .c23 import patch
+try:
+    from importlib import reload
+except ImportError:
+    pass
 
 
 @pytest.mark.parametrize('entry',
@@ -40,10 +45,13 @@ def test_main_parser(entry):
         entrypoint_func.assert_called_with(['-i', '123'])
 
 
-@pytest.mark.parametrize('argv,exc', argvalues=(
-    (['iotlab'], None), (['iotlab', 'help'], None),
-    (['iotlab', '--help'], SystemExit),
-), ids=['no subcommand', 'help subcommand', '--help argument'])
+@pytest.mark.parametrize('argv,exc',
+                         argvalues=((['iotlab'], None),
+                                    (['iotlab', 'help'], None),
+                                    (['iotlab', '--help'], SystemExit),),
+                         ids=['no subcommand',
+                              'help subcommand',
+                              '--help argument'])
 def test_help(argv, exc):
     """Tests that the help entrypoints print the help."""
     with patch.object(argparse.ArgumentParser, 'print_help') \
@@ -55,3 +63,100 @@ def test_help(argv, exc):
         else:
             main_parser.main()
         argparser_print_help.assert_called()
+
+
+def test_main_parser_aggregator():
+    """ Experiment parser """
+    entry = 'aggregator'
+    with patch('iotlabcli.parser.main.aggregator') as entrypoint_func, \
+            patch('iotlabcli.parser.main.AGGREGATION_TOOLS', True):
+        main_parser.main([entry, '-i', '123'])
+        entrypoint_func.assert_called_with(['-i', '123'])
+
+
+def test_main_parser_no_aggregator():
+    """ Experiment parser """
+    with patch('iotlabcli.parser.main.AGGREGATION_TOOLS', False):
+        pytest.raises(SystemExit,
+                      lambda: main_parser.main(['aggregator']))
+
+
+def test_main_parser_oml_plot():
+    """ Experiment parser """
+    entry = 'oml-plot'
+    with patch('iotlabcli.parser.main.oml_plot') as entrypoint_func, \
+            patch('iotlabcli.parser.main.OMLPLOT_TOOLS', True):
+        main_parser.main([entry, '-i', '123'])
+        entrypoint_func.assert_called_with(['-i', '123'])
+
+
+def test_main_parser_no_oml_plot():
+    """ Experiment parser """
+    with patch('iotlabcli.parser.main.OMLPLOT_TOOLS', False):
+        pytest.raises(SystemExit,
+                      lambda: main_parser.main(['oml-plot']))
+
+
+def get_mock_import(func):
+    """factory for mock_import functions"""
+    original_import = __import__
+
+    def mock_import(name, *args, **kwargs):
+        """if package matches, then call the function"""
+        for package in ('iotlabsshcli', 'iotlabaggregator', 'oml_plot_tools'):
+            if package in name:
+                return func()
+
+        return original_import(name, *args, **kwargs)
+
+    return mock_import
+
+
+ENTRIES = [['ssh'], ['aggregator', 'serial'], ['aggregator', 'sniffer'],
+           ['oml-plot', 'consum'], ['oml-plot', 'traj'], ['oml-plot', 'radio']]
+
+BUILTIN_IMPORT = '%s.__import__' % mock.builtin
+
+
+@pytest.mark.parametrize('entry', ENTRIES, ids=' '.join)
+@patch('iotlabcli.parser.main.AGGREGATION_TOOLS', True)
+@patch('iotlabcli.parser.main.OMLPLOT_TOOLS', True)
+@patch('iotlabcli.parser.main.SSH_TOOLS', True)
+def test_main_parser_mocked_import(entry):
+    """ Experiment parser """
+    module_mock = Mock()
+
+    with patch(BUILTIN_IMPORT, get_mock_import(lambda: module_mock)):
+        reload(main_parser)
+        main_parser.main(entry + ['-i', '123'])
+        module_mock.main.assert_called_with(['-i', '123'])
+
+
+def test_main_parser_no_ssh():
+    """ Experiment parser """
+    with patch('iotlabcli.parser.main.SSH_TOOLS', False):
+        pytest.raises(SystemExit,
+                      lambda: main_parser.main(['ssh']))
+
+
+def test_mock_import():
+    """ whether we detect the installed modules correctly """
+    with patch(BUILTIN_IMPORT, get_mock_import(Mock)):
+        reload(main_parser)
+        assert main_parser.AGGREGATION_TOOLS
+        assert main_parser.OMLPLOT_TOOLS
+        assert main_parser.SSH_TOOLS
+
+
+def test_mock_import_not_installed():
+    """ whether we detect the non installed modules correctly """
+
+    def raising_import_error():
+        """raises ImportError"""
+        raise ImportError
+
+    with patch(BUILTIN_IMPORT, get_mock_import(raising_import_error)):
+        reload(main_parser)
+        assert not main_parser.AGGREGATION_TOOLS
+        assert not main_parser.OMLPLOT_TOOLS
+        assert not main_parser.SSH_TOOLS

--- a/iotlabcli/tests/main_parser_test.py
+++ b/iotlabcli/tests/main_parser_test.py
@@ -122,7 +122,7 @@ def test_aggregator_main(entry):
 
     with patch('iotlabcli.parser.main.iotlabaggregator') as mocked_module:
         mocked_main = getattr(mocked_module, entry).main
-        main_parser.main(['aggregator', entry, '-i', '123'])
+        main_parser.main([entry, '-i', '123'])
         mocked_main.assert_called_with(['-i', '123'])
 
 
@@ -133,7 +133,7 @@ def test_oml_main(entry):
 
     with patch('iotlabcli.parser.main.oml_plot_tools') as mocked_module:
         mocked_main = getattr(mocked_module, entry).main
-        main_parser.main(['oml-plot', entry, '-i', '123'])
+        main_parser.main(['plot', entry, '-i', '123'])
         mocked_main.assert_called_with(['-i', '123'])
 
 
@@ -147,19 +147,10 @@ def test_ssh_main():
         mocked_main.assert_called_with(['-i', '123'])
 
 
-@with_aggregator_tools
-def test_main_parser_aggregator():
-    """ Experiment parser """
-    entry = 'aggregator'
-    with patch('iotlabcli.parser.main.aggregator') as entrypoint_func:
-        main_parser.main([entry, '-i', '123'])
-        entrypoint_func.assert_called_with(['-i', '123'])
-
-
 @with_oml_plot_tools
 def test_main_parser_oml_plot():
     """ Experiment parser """
-    entry = 'oml-plot'
+    entry = 'plot'
     with patch('iotlabcli.parser.main.oml_plot') as entrypoint_func:
         main_parser.main([entry, '-i', '123'])
         entrypoint_func.assert_called_with(['-i', '123'])

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ def get_version(package):
 
 
 SCRIPTS = ['iotlab-auth', 'iotlab-experiment', 'iotlab-node', 'iotlab-profile',
-           'iotlab-robot', 'iotlab-admin']
+           'iotlab-robot', 'iotlab-admin', 'iotlab']
+
 DEPRECATED_SCRIPTS = ['auth-cli', 'experiment-cli', 'node-cli', 'profile-cli',
                       'robot-cli', 'admin-cli']
 SCRIPTS += DEPRECATED_SCRIPTS

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ usedevelop = False
 commands =
     python setup.py check --strict --metadata --restructuredtext
 
-[testenv:coverage]
+[testenv:coverage_upload]
 passenv = CI TRAVIS TRAVIS_*
 commands = codecov -e TOXENV
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,14 +18,13 @@ commands=
 
 [testenv:tests]
 commands=
-    py.test --cov=iotlabcli --cov-report=term --cov-report=xml --cov-report=html
+    py.test --cov-append --cov=iotlabcli --cov-report=term --cov-report=xml --cov-report=html
 
 [testenv:tools]
 deps=
     git+https://github.com/iot-lab/oml-plot-tools.git#egg=oml_plot_tools
     git+https://github.com/iot-lab/ssh-cli-tools.git#egg=iotlabsshclitools
     git+https://github.com/iot-lab/aggregation-tools.git#egg=iotlabaggregator
-setenv = TEST_IOTLAB_TOOLS = true
 commands=
     {[testenv:tests]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands=
 
 [testenv:tests]
 commands=
-    py.test --cov-append --cov=iotlabcli --cov-report=term --cov-report=xml --cov-report=html
+    py.test --cov=iotlabcli --cov-report=term --cov-report=xml --cov-report=html
 
 [testenv:tools]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,9 @@ commands=
     bash -exc "for i in *-cli; do $i --help >/dev/null; done"
     bash -exc "for i in auth experiment node profile robot; \
     do iotlab-$i --help > /dev/null; done"
+    bash -exc "iotlab help > /dev/null";
+    bash -exc "iotlab --help > /dev/null";
+    bash -exc "iotlab > /dev/null";
 
 [testenv:checksetup]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying,{py27,py34,py35,py36,py37}-{lint,tests,cli,checksetup}
+envlist = copying,{py27,py34,py35,py36,py37}-{lint,tests,tools,cli,checksetup}
 
 [testenv]
 whitelist_externals =
@@ -7,8 +7,10 @@ whitelist_externals =
 deps=
     -rtests_utils/test-requirements.txt
     checksetup: {[testenv:checksetup]deps}
+    tools: {[testenv:tools]deps}
 commands=
     tests:      {[testenv:tests]commands}
+    tools:      {[testenv:tools]commands}
     lint:       {[testenv:lint]commands}
     cli:        {[testenv:cli]commands}
     checksetup: {[testenv:checksetup]commands}
@@ -17,6 +19,15 @@ commands=
 [testenv:tests]
 commands=
     py.test --cov=iotlabcli --cov-report=term --cov-report=xml --cov-report=html
+
+[testenv:tools]
+deps=
+    git+https://github.com/iot-lab/oml-plot-tools.git#egg=oml_plot_tools
+    git+https://github.com/iot-lab/ssh-cli-tools.git#egg=iotlabsshclitools
+    git+https://github.com/iot-lab/aggregation-tools.git#egg=iotlabaggregator
+setenv = TEST_IOTLAB_TOOLS = true
+commands=
+    {[testenv:tests]commands}
 
 [testenv:lint]
 commands=


### PR DESCRIPTION
Ever since the commands were renamed to iotlab-*, I've thought, hey why not go all the way and make all the commands subcommands of a single `iotlab` command.

Simply installing an `iotlab` script, with a single argument 'command', then passing the rest of the arguments to the subcommand. 
- Calling `iotlab`, `iotlab help` or `iotlab --help` will show help with all the subcommand names
- No changes to the iotlab-* subcommands

This doesnt seem to decrease the 100% coverage. 