### PR TITLE
Files duplicate basenames

### DIFF
--- a/iotlabcli/experiment.py
+++ b/iotlabcli/experiment.py
@@ -64,14 +64,18 @@ def submit_experiment(api, name, duration,  # pylint:disable=too-many-arguments
 
     exp_files = helpers.FilesDict()
     for res_dict in resources:
+        inserted_resources = exp_files.add_files_from_dict(
+            NODES_ASSOCIATIONS_FILE_ASSOCS, res_dict)
+        res_dict.update(inserted_resources)
         experiment.add_exp_resources(res_dict)
-        exp_files.add_files_from_dict(NODES_ASSOCIATIONS_FILE_ASSOCS, res_dict)
 
     sites_assocs = sites_assocs or ()
     for site_assoc in sites_assocs:
-        experiment.add_site_association(site_assoc)
         assocs = site_assoc.associations
-        exp_files.add_files_from_dict(SITE_ASSOCIATIONS_FILE_ASSOCS, assocs)
+        inserted_assocs = exp_files.add_files_from_dict(
+            SITE_ASSOCIATIONS_FILE_ASSOCS, assocs)
+        assocs.update(inserted_assocs)
+        experiment.add_site_association(site_assoc)
 
     if print_json:  # output experiment description
         return experiment
@@ -271,7 +275,9 @@ def _script_run_files_dict(*site_associations):
     for sites, assocs in site_associations:
         for assoctype, assocname in assocs.items():
             _add_siteassoc_to_dict(associations, sites, assoctype, assocname)
-        files_dict.add_files_from_dict(SITE_ASSOCIATIONS_FILE_ASSOCS, assocs)
+        inserted_assocs = files_dict.add_files_from_dict(
+            SITE_ASSOCIATIONS_FILE_ASSOCS, assocs)
+        assocs.update(inserted_assocs)
 
     # Add scrit sites association to files_dict
     files_dict[RUN_FILENAME] = helpers.json_dumps(associations)

--- a/iotlabcli/helpers.py
+++ b/iotlabcli/helpers.py
@@ -159,23 +159,6 @@ class FilesDict(dict):
     """ Dictionary to store experiment files.
     We don't want adding two different values for the same key,
     so __setitem__ is overriden to check that
-
-    >>> file_dict = FilesDict()
-
-    # can re-add same value
-    >>> file_dict['test'] = 'value'
-    >>> file_dict['test'] = 'value'
-
-    >>> file_dict['test2'] = 'value'
-    >>> file_dict['test3'] = 'value3'
-    >>> file_dict == {'test': 'value', 'test3': 'value3', 'test2': 'value'}
-    True
-
-    # cannot add a new value to an existing key
-
-    >>> file_dict['test'] = 'a_new_value'
-    Traceback (most recent call last):
-    ValueError: Has different values for same key 'test'
     """
     def __init__(self):
         dict.__init__(self)

--- a/iotlabcli/tests/experiment_test.py
+++ b/iotlabcli/tests/experiment_test.py
@@ -120,6 +120,47 @@ class TestExperimentSubmit(CommandMock):
                                            print_json=True)
         self.assertEqual(ret.__dict__, expected)
 
+    def test_experiment_submit_duplicated_basenames(self):
+        """ Run experiment_submit physical """
+
+        # Physical tests
+        resources = [
+            experiment.exp_resources(
+                ['m3-1.grenoble.iot-lab.info'],
+                tests.resource_file('firmware.elf')),
+            experiment.exp_resources(
+                ['m3-2.grenoble.iot-lab.info'],
+                tests.resource_file('other/firmware.elf')),
+        ]
+        experiment.submit_experiment(self.api, 'exp_name', 20, resources,
+                                     start_time=314159)
+
+        call_dict = self.api.submit_experiment.call_args[0][0]
+        expected = {
+            'name': 'exp_name',
+            'duration': 20,
+            'type': 'physical',
+            'nodes': [
+                'm3-1.grenoble.iot-lab.info',
+                'm3-2.grenoble.iot-lab.info',
+            ],
+            'reservation': 314159,
+            'profileassociations': None,
+            'firmwareassociations': [
+                {'firmwarename':
+                 'e77d9b8dcb84d1fcd21187b03eac74f1_firmware.elf',
+                 'nodes': ['m3-2.grenoble.iot-lab.info']},
+                {'firmwarename': 'firmware.elf',
+                 'nodes': ['m3-1.grenoble.iot-lab.info']},
+            ],
+            'associations': None,
+            'siteassociations': None,
+            'profiles': None,
+            'mobilities': None,
+        }
+
+        self.assertEqual(expected, json.loads(call_dict['new_exp.json']))
+
     def test_experiment_submit_alias(self):
         """ Run experiment_submit alias """
         # Alias tests

--- a/iotlabcli/tests/other/firmware.elf
+++ b/iotlabcli/tests/other/firmware.elf
@@ -1,0 +1,1 @@
+different


### PR DESCRIPTION
As discussed this morning.

The heart of the matter is `iotlabcli.helpers.FilesDict` which is the class responsible for storing experiment files before they are shipped off in multipart. It couldn't handle two different files with the same basename because the indexing key is the basename and it errors when modifying an element to a different value.

I've modified the add_file method to be able to handle duplicated basenames with different content, modifying the file name to prepend the MD5 hash. 
I've modified add_files_from_dict so that this method modifies the input files_dict (containing the association between nodes and firmwares, etc), that might be considered a feature (we can thus e.g. print the submission with the modified firmware names in it before being sent).

In the process, I've migrated that part to pytest (doctests included), I should probably make that (
47551ee) a fully separate commit 
