### PR TITLE
Fix iotlab

### DIFF
--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -48,6 +48,9 @@ except ImportError:
 # from oml-plot-tools
 try:
     import oml_plot_tools
+    import oml_plot_tools.consum
+    import oml_plot_tools.radio
+    import oml_plot_tools.traj
 except (ImportError, SyntaxError, TypeError):
     oml_plot_tools = None  # pylint:disable=invalid-name
 

--- a/iotlabcli/parser/main.py
+++ b/iotlabcli/parser/main.py
@@ -55,18 +55,18 @@ except (ImportError, SyntaxError, TypeError):
     oml_plot_tools = None  # pylint:disable=invalid-name
 
 
-def parse_subcommands(commands, args=None):
+def parse_subcommands(commands, args):
     """ common function to parse `iotlab` or other with subcommands """
-    args = args or sys.argv[1:]
 
     parser = ArgumentParser()
+    commands['help'] = lambda args: parser.print_help()
     parser.add_argument('command', nargs='?',
                         choices=commands.keys(), default='help')
-    commands['help'] = lambda args: parser.print_help()
 
-    opts, args = parser.parse_known_args(args)
+    opts, _ = parser.parse_known_args(args[:1])
 
-    return commands[opts.command](args)
+    sys.argv[0] = 'iotlab %s' % opts.command
+    return commands[opts.command](args[1:])
 
 
 def oml_plot(args):
@@ -82,6 +82,7 @@ def oml_plot(args):
 
 def main(args=None):
     """'iotlab' main function."""
+    args = args or sys.argv[1:]
 
     commands = {
         'auth': iotlabcli.parser.auth.main,
@@ -89,8 +90,7 @@ def main(args=None):
         'experiment': iotlabcli.parser.experiment.main,
         'node': iotlabcli.parser.node.main,
         'profile': iotlabcli.parser.profile.main,
-        'robot': iotlabcli.parser.robot.main,
-        'help': None
+        'robot': iotlabcli.parser.robot.main
     }
     if iotlabaggregator:
         commands['serial'] = iotlabaggregator.serial.main

--- a/iotlabcli/tests/main_parser_test.py
+++ b/iotlabcli/tests/main_parser_test.py
@@ -21,6 +21,7 @@
 
 """ Test the iotlabcli.experiment_parser module """
 import argparse
+import subprocess
 
 import sys
 
@@ -125,9 +126,11 @@ def test_aggregator_main(entry):
         main_parser.main([entry, '-i', '123'])
         mocked_main.assert_called_with(['-i', '123'])
 
+    assert subprocess.check_call(['iotlab', entry, '--help']) == 0
+
 
 @with_oml_plot_tools
-@pytest.mark.parametrize('entry', ('consum', 'traj', 'radio'))
+@pytest.mark.parametrize('entry', ('traj', 'radio', 'consum'))
 def test_oml_main(entry):
     """ test main parser dispatching for subcommands"""
 
@@ -135,6 +138,9 @@ def test_oml_main(entry):
         mocked_main = getattr(mocked_module, entry).main
         main_parser.main(['plot', entry, '-i', '123'])
         mocked_main.assert_called_with(['-i', '123'])
+
+    assert subprocess.check_call(['iotlab', 'plot', '--help']) == 0
+    assert subprocess.check_call(['iotlab', 'plot', entry, '--help']) == 0
 
 
 @with_ssh_tools
@@ -146,14 +152,7 @@ def test_ssh_main():
         main_parser.main(['ssh', '-i', '123'])
         mocked_main.assert_called_with(['-i', '123'])
 
-
-@with_oml_plot_tools
-def test_main_parser_oml_plot():
-    """ Experiment parser """
-    entry = 'plot'
-    with patch('iotlabcli.parser.main.oml_plot') as entrypoint_func:
-        main_parser.main([entry, '-i', '123'])
-        entrypoint_func.assert_called_with(['-i', '123'])
+    assert subprocess.check_call(['iotlab', 'ssh', '--help']) == 0
 
 
 @without_tools
@@ -162,9 +161,11 @@ def test_main_parser_no_tools():
     pytest.raises(SystemExit,
                   lambda: main_parser.main(['ssh']))
     pytest.raises(SystemExit,
-                  lambda: main_parser.main(['aggregator']))
+                  lambda: main_parser.main(['serial']))
     pytest.raises(SystemExit,
-                  lambda: main_parser.main(['oml-plot']))
+                  lambda: main_parser.main(['sniffer']))
+    pytest.raises(SystemExit,
+                  lambda: main_parser.main(['plot']))
 
 
 @with_aggregator_tools


### PR DESCRIPTION
The `iotlab` common command had some problems, probably something changed when simplifying something, 
- for `plot` subcommand: oml_plot_tools import hierarchy needed to go one level deeper (use `import oml_plot_tools.consum` instead of `import oml_plot_tools` then use `oml_plot_tools.consum.main`)
- wrong `prog`: `iotlab node --help` or `iotlab node` showed wrong usage `prog`(sys.argv[0]) (`iotlab` only instead of `iotlab node`
- `iotlab subcommand` was not tested for the "tools" subcommands (serial/sniffer/plot/ssh)

PS: it might be a good roadmap to migrate in the future to something that better handle hierarchy of subcommands, like click or others, instead of argparse which is a bit limited in that regard
