### PR TITLE
Add flash binary support

### DIFF
--- a/iotlabcli/node.py
+++ b/iotlabcli/node.py
@@ -25,6 +25,29 @@ import json
 from iotlabcli import helpers
 
 NODE_FILENAME = 'nodes.json'
+EXPERIMENT = 'experiment.json'
+
+
+def _node_command_flash(api, exp_id, nodes_list, cmd_opt):
+    assert cmd_opt is not None, '`cmd_opt` required for update'
+    files = helpers.FilesDict()
+
+    files.add_file(cmd_opt)
+    if cmd_opt.endswith('.bin'):
+        files[EXPERIMENT] = json.dumps({'nodes': nodes_list, 'offset': 0})
+        return api.node_update(exp_id, files, binary=True)
+
+    files[NODE_FILENAME] = json.dumps(nodes_list)
+    return api.node_update(exp_id, files)
+
+
+def _node_command_profile_load(api, exp_id, nodes_list, cmd_opt):
+    assert cmd_opt is not None, '`cmd_opt` required for update'
+    files = helpers.FilesDict()
+
+    files.add_file(cmd_opt)
+    files[NODE_FILENAME] = json.dumps(nodes_list)
+    return api.node_profile_load(exp_id, files)
 
 
 def node_command(api, command, exp_id, nodes_list=(), cmd_opt=None):
@@ -45,19 +68,9 @@ def node_command(api, command, exp_id, nodes_list=(), cmd_opt=None):
 
     result = None
     if command == 'flash':
-        assert cmd_opt is not None, '`cmd_opt` required for update'
-        files = helpers.FilesDict()
-
-        files.add_file(cmd_opt)
-        files[NODE_FILENAME] = json.dumps(nodes_list)
-        result = api.node_update(exp_id, files)
+        result = _node_command_flash(api, exp_id, nodes_list, cmd_opt)
     elif command == 'profile-load':
-        assert cmd_opt is not None, '`cmd_opt` required for update'
-        files = helpers.FilesDict()
-
-        files.add_file(cmd_opt)
-        files[NODE_FILENAME] = json.dumps(nodes_list)
-        result = api.node_profile_load(exp_id, files)
+        result = _node_command_profile_load(api, exp_id, nodes_list, cmd_opt)
     elif command == 'profile':
         cmd_opt = '&name={}'.format(cmd_opt)
         result = api.node_command(command, exp_id, nodes_list, cmd_opt)

--- a/iotlabcli/rest.py
+++ b/iotlabcli/rest.py
@@ -171,7 +171,7 @@ class Api():  # pylint:disable=too-many-public-methods
             url += '/%s' % option
         return self.method(url, 'post', json=nodes)
 
-    def node_update(self, expid, files):
+    def node_update(self, expid, files, binary=False):
         """ Launch update command (flash firmware) on user
         experiment list nodes
 
@@ -180,8 +180,10 @@ class Api():  # pylint:disable=too-many-public-methods
         :type files: dict
         :returns: dict
         """
-        return self.method('experiments/%s/nodes/flash' % expid,
-                           'post', files=files)
+        url = 'experiments/{}/nodes/flash'.format(expid)
+        if binary:
+            url += '/binary'
+        return self.method(url, 'post', files=files)
 
     def node_profile_load(self, expid, files):
         """Update profile with profile json on user


### PR DESCRIPTION
This PR extends the "iotlab node --flash" command with the capability to flash firmwares with the .bin extension.

A test is added.