### PR TITLE
utils/bash-completion: remove deprecated sites

### DIFF
--- a/utils/iotlabcli-bash-completion.sh
+++ b/utils/iotlabcli-bash-completion.sh
@@ -1,6 +1,6 @@
 # iotlab-* completion
 
-_iotlab_sites=(euratech strasbourg paris grenoble rennes lille saclay lyon)
+_iotlab_sites=(strasbourg paris grenoble lille saclay lyon)
 _iotlab_archis=(wsn430 a8 m3 firefly arduino-zero samr21 st-lrwan1)
 _iotlab_states=(Waiting toLaunch Launching Running Finishing Stopped Terminated Error)
 


### PR DESCRIPTION
This PR removes iotlab sites that doesn't exist anymore (euratech and rennes) from the bash_completion script.