### PR TITLE
Add options in iotlab-auth for setting an SSH key

### DIFF
--- a/iotlabcli/auth.py
+++ b/iotlabcli/auth.py
@@ -21,6 +21,8 @@
 
 """ Authentication file management """
 
+from __future__ import print_function
+
 import os
 import os.path
 import getpass
@@ -85,3 +87,39 @@ def _read_password_file():
             return username, password
     except ValueError:
         raise ValueError('Bad password file format: %r' % RC_FILE)
+
+
+IDENTITY_FILE = os.path.expanduser('~/.ssh/id_rsa')
+
+
+def add_ssh_key(identity_file=None):
+    """Install ssh key into user's iot-lab account"""
+
+    if identity_file is None:
+        identity_file = IDENTITY_FILE
+
+    api = Api(*get_user_credentials())
+    keys_json = api.get_ssh_keys()
+    pub_key = identity_file + '.pub'
+    with open(pub_key) as key_fh:
+        key = key_fh.read().strip()
+
+    keys = keys_json['sshkeys']
+    if key in keys:
+        msg = 'Key is already configured:\n"{}"'.format(key)
+        raise ValueError(msg)
+
+    keys.append(key)
+
+    api.set_ssh_keys(keys_json)
+
+
+def ssh_keys():
+    """List ssh keys configured into user's iot-lab account"""
+
+    api = Api(*get_user_credentials())
+    keys_json = api.get_ssh_keys()
+
+    print("SSH keys:")
+    for key in keys_json['sshkeys']:
+        print(key)

--- a/iotlabcli/rest.py
+++ b/iotlabcli/rest.py
@@ -262,7 +262,18 @@ class Api():  # pylint:disable=too-many-public-methods
                 return False
             raise  # pragma no cover
 
-# robot
+    # ssh keys api
+
+    def get_ssh_keys(self):
+        """ Get user's registered ssh keys """
+        ret = self.method('user/keys')
+        return ret
+
+    def set_ssh_keys(self, ssh_keys_json):
+        """ Set user's ssh keys """
+        self.method('user/keys', 'post', json=ssh_keys_json, raw=True)
+
+    # robot
 
     def robot_command(self, command, expid, nodes=()):
         """Run 'status' on user experiment robot list nodes.

--- a/iotlabcli/tests/auth_parser_test.py
+++ b/iotlabcli/tests/auth_parser_test.py
@@ -25,16 +25,20 @@ import sys
 import unittest
 
 import iotlabcli.parser.auth as auth_parser
+from iotlabcli import auth
+
 from .c23 import patch
 
 # pylint: disable=missing-docstring,too-many-public-methods
 
 
 @patch('sys.stderr', sys.stdout)
+@patch('iotlabcli.auth.ssh_keys')
+@patch('iotlabcli.auth.add_ssh_key')
 @patch('iotlabcli.auth.write_password_file')
 class TestMainAuthParser(unittest.TestCase):
     @patch('getpass.getpass')
-    def test_main(self, getpass_m, store_m):
+    def test_main(self, getpass_m, store_m, ssh_key_m, ssh_keys_m):
         """ Test parser.auth.main function """
         store_m.return_value = 'Written'
         getpass_m.return_value = 'password2'
@@ -56,10 +60,45 @@ class TestMainAuthParser(unittest.TestCase):
             self.assertTrue(getpass_m.called)
             self.assertEqual(0, store_m.call_count)
 
-    def test_main_exceptions(self, store_m):
+            # -u/--user is required
+            self.assertRaises(SystemExit, auth_parser.main, ['-p', 'test'])
+
+            # SSH key file
+            auth_parser.main(['--add-ssh-key'])
+            ssh_key_m.assert_called_with(auth.IDENTITY_FILE)
+
+            auth_parser.main(['--add-ssh-key', '--identity-file', 'test'])
+            ssh_key_m.assert_called_with('test')
+
+            # Add ssh key with -u/-p options but key is already set
+            ssh_key_m.reset_mock()
+            api.check_credential.return_value = True
+            store_m.return_value = 'Written'
+            ssh_key_m.side_effect = ValueError('key message')
+            auth_parser.main(['-u', 'super_user', '-p', 'password',
+                              '--add-ssh-key'])
+            store_m.assert_called_with('super_user', 'password')
+            ssh_key_m.assert_called_with(auth.IDENTITY_FILE)
+
+            # List SSH keys
+            auth_parser.main(['--list-ssh-key'])
+            ssh_keys_m.assert_called_once()
+
+            # List ssh key with -u/-p options
+            ssh_key_m.reset_mock()
+            ssh_keys_m.call_count = 0
+            api.check_credential.return_value = True
+            store_m.return_value = 'Written'
+            auth_parser.main(['-u', 'super_user', '-p', 'password',
+                              '--list-ssh-keys'])
+            store_m.assert_called_with('super_user', 'password')
+            ssh_keys_m.assert_called_once()
+
+    def test_main_exceptions(self, store_m, ssh_key_m, ssh_keys_m):
         """ Test parser.auth.main error cases """
         # Replacing 'side_effect'
         # pylint:disable=redefined-variable-type
+        # pylint:disable=unused-argument
         with patch('iotlabcli.auth.Api') as api_class:
             api = api_class.return_value
             api.check_credential.return_value = True
@@ -71,3 +110,7 @@ class TestMainAuthParser(unittest.TestCase):
             store_m.side_effect = KeyboardInterrupt()
             self.assertRaises(SystemExit, auth_parser.main,
                               ['-u', 'ctrl_c', '-p', 'password'])
+
+            ssh_key_m.side_effect = ValueError('message')
+            self.assertRaises(SystemExit, auth_parser.main,
+                              ['--add-ssh-key'])

--- a/iotlabcli/tests/rest_test.py
+++ b/iotlabcli/tests/rest_test.py
@@ -23,7 +23,7 @@
 
 # pylint: disable=too-many-public-methods
 # pylint: disable=protected-access
-
+import json
 import unittest
 
 from iotlabcli import rest
@@ -131,6 +131,16 @@ class TestRest(unittest.TestCase):
         ret_val.status_code = 500
         self.assertRaises(HTTPError, self.api.check_credential)
 
+        patch.stopall()
+
+    def test_ssh_key(self):
+        """ Test ssh keys get/set """
+        test_ssh_keys = '{"sshkey": ["test"]}'
+        test_ssh_keys_json = json.loads(test_ssh_keys)
+        ret_val = RequestRet(200, content=test_ssh_keys)
+        patch('requests.request', return_value=ret_val).start()
+        assert self.api.get_ssh_keys() == test_ssh_keys_json
+        assert self.api.set_ssh_keys(test_ssh_keys_json) is None
         patch.stopall()
 
     def test_method_raw(self):


### PR DESCRIPTION
This PR is a rework from #5.

closes #5 