### PR TITLE
associations: use collections.abc instead of collections

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@master

--- a/iotlabcli/associations.py
+++ b/iotlabcli/associations.py
@@ -33,7 +33,7 @@ Dumped JSON format is:
 """
 
 import abc
-import collections
+import collections.abc
 
 
 def _disabled_method(*_):
@@ -55,7 +55,7 @@ def setattrdefault(obj, attribute, default=None):
 
 class _Association(
         # pylint: disable=too-many-ancestors
-        collections.MutableMapping, dict):
+        collections.abc.MutableMapping, dict):
     """_Association class key->value.
 
     Inherit from dict to be dumped as a dict by json.
@@ -203,7 +203,7 @@ class _Association(
 class AssociationsMap(
         # pylint:disable=too-many-public-methods
         # pylint: disable=too-many-ancestors
-        collections.MutableMapping, list):
+        collections.abc.MutableMapping, list):
     """Sorted Map of Associations objects.
 
     Inherit list to be json serialized to a list.


### PR DESCRIPTION
Using or importing the ABCs from `collections` instead of from `collections.abc` is deprecated since Python 3.3, and in 3.10 it will stop working. Since Python 3.10 was released a few month ago, and starting to get deployed in operating systems such as Arch or Fedora, this should be fixed ASAP.