### PR TITLE
tests: Fix import error for c23 module

### DIFF
--- a/iotlabcli/tests/c23.py
+++ b/iotlabcli/tests/c23.py
@@ -34,13 +34,12 @@ if version_info[0] == 2:  # pragma: no cover
     from urllib2 import HTTPError
     import mock
     from cStringIO import StringIO
+    from mock import patch, Mock, mock_open  # noqa
 elif version_info[0] == 3:  # pragma: no cover
     # python3
     from urllib.error import HTTPError
     from unittest import mock
+    from unittest.mock import patch, Mock, mock_open  # noqa
     from io import StringIO
 else:  # pragma: no cover
     raise ValueError(f'Unknown python version {version_info!r}')
-
-# pylint:disable=wrong-import-position
-from mock import patch, Mock, mock_open  # noqa


### PR DESCRIPTION
For some strange reason, it seems like using
```py
from module_a import module_b
from module_b import module_c
```
will not work... I guess any from imports must be an existing module and cannot be something brought in.
_Note_  in this example `module_b` is usable just not "from" importable.

We have had some failing tests which I was able to reproduce locally.

In this case it is regarding the mock -> python2 and unittest.mock -> python3 abstraction.

One can use or print the imported mock, but cannot `from x import y` it.

The solution is to just import all the `from x import y` within the version abstraction branch.

It has been locally tested allowing mock to still be used.

The failure was discovered during [RIOT release tests](https://github.com/RIOT-OS/RIOT/actions/runs/5492353518/jobs/10087647957#step:14:66)